### PR TITLE
Fix full fluid transmitters getting stuck full

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,8 +1,10 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.17.1
-Date: 02. 11. 2020
+Date: 03. 10. 2020
   Features:
     - Allow separate X and Y settings for PlaceableArea.
+  Bugfixes:
+    - Fixed fluidtransmitters getting stuck when full.
 ---------------------------------------------------------------------------------------------------
 Version: 1.17.0
 Date: 01. 26. 2020

--- a/src/control.lua
+++ b/src/control.lua
@@ -487,10 +487,10 @@ function HandleInputTank(entityData)
 		local fluid = fluidbox[1]
 		if fluid ~= nil and math.floor(fluid.amount) > 0 then
 			if isFluidLegal(fluid.name) then
-				local fluid_left = fluid.amount - math.floor(fluid.amount)
-				if fluid_left > 0 then
-					AddItemToInputList(fluid.name, math.floor(fluid.amount))
-					fluid.amount = fluid_left
+				if fluid.amount > 1 then
+					local fluid_taken = math.ceil(fluid.amount) - 1
+					AddItemToInputList(fluid.name, fluid_taken)
+					fluid.amount = fluid.amount - fluid_taken
 					fluidbox[1] = fluid
 				end
 			end


### PR DESCRIPTION
If a fluid transmitter ends up filling up completely it'll have an integer amount of fluid in it, which resulted in the input code skipping it as there would be no fluid left after taking the floor of the amount from the tank.

Fix by taking the ceiling of the stored amount minus one.  Fixes #40.