### PR TITLE
Fix that fluids could be duplicated when requested

### DIFF
--- a/src/control.lua
+++ b/src/control.lua
@@ -574,8 +574,6 @@ function GetOutputTankRequest(requests, entityData)
 			--If the entity is missing fluid than add a request for fluid
 			if missingFluid > 0 then
 				local entry = AddRequestToTable(requests, fluidName, missingFluid, entity)
-				--Add fluid to the request so it doesn't have to be created again
-				entry.fluid = fluid
 				entry.fluidbox = fluidbox
 			end
 		end
@@ -623,16 +621,17 @@ function OutputChestInputMethod(request, itemName, evenShareOfItems)
 	end
 end
 
-function OutputTankInputMethod(request, _, evenShareOfFluid)
+function OutputTankInputMethod(request, fluidName, evenShareOfFluid)
 	if request.storage.valid then
-		request.fluid.amount = request.fluid.amount + evenShareOfFluid
+		local fluid = request.fluidbox[1] or {name = fluidName, amount = 0}
+		fluid.amount = fluid.amount + evenShareOfFluid
 
 		--Need to set steams heat because otherwise it's too low
-		if request.fluid.name == "steam" then
-			request.fluid.temperature = 165
+		if fluid.name == "steam" then
+			fluid.temperature = 165
 		end
 
-		request.fluidbox[1] = request.fluid
+		request.fluidbox[1] = fluid
 		return evenShareOfFluid
 	else
 		return 0


### PR DESCRIPTION
Fluid extractor would make a request and store its current fluid amount in the request.
When it came to refill the tank, it would use its old fluid amount,from the request, instead of its current one.
All the fluid that were removed from the tank in the time between making and fulfilling the fluid request would be duplicated.

fixes #49