### PR TITLE
Fix extractors failing to send requests to master

### DIFF
--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,4 +1,8 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.99.4
+  Bugfixes:
+    - Fixed extractors failing to request items from master.
+---------------------------------------------------------------------------------------------------
 Version: 1.99.2
   Features:
     - New placeholder artwork for the subspace interactors.

--- a/src/control.lua
+++ b/src/control.lua
@@ -317,7 +317,7 @@ script.on_event(defines.events.on_tick, function(event)
 			if global.workTick == 0 then
 				ResetRequestGathering()
 			end
-			RetrieveGetterRequests(global.allowedToMakeElectricityRequests, TICKS_TO_COLLECT_REQUESTS + global.workTick)
+			RetrieveGetterRequests(global.allowedToMakeElectricityRequests, TICKS_TO_COLLECT_REQUESTS - global.workTick)
 		elseif global.workTick >= TICKS_TO_COLLECT_REQUESTS and global.workTick < TICKS_TO_COLLECT_REQUESTS + TICKS_TO_FULFILL_REQUESTS then
 			if global.workTick == TICKS_TO_COLLECT_REQUESTS then
 				UpdateUseableStorage()

--- a/src/info.json
+++ b/src/info.json
@@ -1,6 +1,6 @@
 {
     "name": "subspace_storage",
-    "version": "1.99.2",
+    "version": "1.99.4",
     "title": "Subspace Storage (Alpha)",
     "author": "Clusterio Team",
     "homepage": "https://github.com/clusterio/factorioClusterio",


### PR DESCRIPTION
Fix wrong runs_left being passed to the partial_ipairs iteration of the extractors.