### PR TITLE
Factorio 1.1 update for Subspace Storage

### DIFF
--- a/build.js
+++ b/build.js
@@ -111,7 +111,7 @@ async function buildMod(args, info) {
 				});
 			await events.once(walker, 'end');
 
-			for (let [fileName, pathParts] of Object.entries(info.additional_files) || []) {
+			for (let [fileName, pathParts] of Object.entries(info.additional_files || {})) {
 				let filePath = path.join(args.sourceDir, ...pathParts);
 				if (!await fs.pathExists(filePath)) {
 					throw new Error(`Additional file ${filePath} does not exist`);

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -6,6 +6,7 @@ Version: 1.99.7
     - Item extractors have unlimited request slots in Factorio 1.1.
   Bugfixes:
     - Fixed extractors and injectors randomly stop working when others are removes elsewhere.
+    - Fixed interactors not accepting circuit wire connections.
 ---------------------------------------------------------------------------------------------------
 Version: 1.99.4
   Bugfixes:

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,4 +1,8 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.99.6
+  Bugfixes:
+    - Fixed extractors and injectors randomly stop working when others are removes elsewhere.
+---------------------------------------------------------------------------------------------------
 Version: 1.99.4
   Bugfixes:
     - Fixed extractors failing to request items from master.

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------------------------------
-Version: 1.99.7
+Version: 1.99.6
   Changes:
     - Adjusted collision box to allow walking between subspace interactors.
     - Added support for Factorio 1.1.

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,5 +1,7 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.99.6
+  Changes:
+    - Adjusted collision box to allow walking between subspace interactors.
   Bugfixes:
     - Fixed extractors and injectors randomly stop working when others are removes elsewhere.
 ---------------------------------------------------------------------------------------------------

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -7,6 +7,7 @@ Version: 1.99.7
   Bugfixes:
     - Fixed extractors and injectors randomly stop working when others are removes elsewhere.
     - Fixed interactors not accepting circuit wire connections.
+    - Fixed inventory combinator breaking when more than 2^31-1 itemes were stored.
 ---------------------------------------------------------------------------------------------------
 Version: 1.99.4
   Bugfixes:

--- a/src/changelog.txt
+++ b/src/changelog.txt
@@ -1,7 +1,9 @@
 ---------------------------------------------------------------------------------------------------
-Version: 1.99.6
+Version: 1.99.7
   Changes:
     - Adjusted collision box to allow walking between subspace interactors.
+    - Added support for Factorio 1.1.
+    - Item extractors have unlimited request slots in Factorio 1.1.
   Bugfixes:
     - Fixed extractors and injectors randomly stop working when others are removes elsewhere.
 ---------------------------------------------------------------------------------------------------

--- a/src/compat/factorio_0.17.lua
+++ b/src/compat/factorio_0.17.lua
@@ -5,7 +5,7 @@ function compat.set_parameters(combinator, parameters)
 end
 
 function compat.version_ge(major, minor)
-	return major > 0 or major == 0 and minor >= 17
+	return major == 0 and minor <= 17
 end
 
 return compat

--- a/src/compat/factorio_0.17.lua
+++ b/src/compat/factorio_0.17.lua
@@ -1,0 +1,11 @@
+local compat = {}
+
+function compat.set_parameters(combinator, parameters)
+	combinator.parameters = { parameters = parameters }
+end
+
+function compat.version_ge(major, minor)
+	return major > 0 or major == 0 and minor >= 17
+end
+
+return compat

--- a/src/compat/factorio_1.0.lua
+++ b/src/compat/factorio_1.0.lua
@@ -1,0 +1,11 @@
+local compat = {}
+
+function compat.set_parameters(combinator, parameters)
+	combinator.parameters = { parameters = parameters }
+end
+
+function compat.version_ge(major, minor)
+	return major > 0
+end
+
+return compat

--- a/src/compat/factorio_1.0.lua
+++ b/src/compat/factorio_1.0.lua
@@ -5,7 +5,7 @@ function compat.set_parameters(combinator, parameters)
 end
 
 function compat.version_ge(major, minor)
-	return major > 0
+	return major < 1 or major == 1 and minor == 0
 end
 
 return compat

--- a/src/compat/factorio_1.1.lua
+++ b/src/compat/factorio_1.1.lua
@@ -5,7 +5,7 @@ function compat.set_parameters(combinator, parameters)
 end
 
 function compat.version_ge(major, minor)
-	return major > 1 or major == 1 and minor >= 1
+	return major < 1 or major == 1 and minor <= 1
 end
 
 return compat

--- a/src/compat/factorio_1.1.lua
+++ b/src/compat/factorio_1.1.lua
@@ -1,0 +1,11 @@
+local compat = {}
+
+function compat.set_parameters(combinator, parameters)
+	combinator.parameters = parameters
+end
+
+function compat.version_ge(major, minor)
+	return major > 1 or major == 1 and minor >= 1
+end
+
+return compat

--- a/src/control.lua
+++ b/src/control.lua
@@ -1,8 +1,10 @@
 require("util")
 require("config")
-require("mod-gui")
+local mod_gui = require("mod-gui")
 
 local clusterio_api = require("__clusterio_lib__/api")
+
+local compat = require("compat")
 
 
 ------------------------------------------------------------
@@ -528,7 +530,7 @@ function GetOutputChestRequest(requests, entityData)
 	--as that just leads to unnecessary bot work
 	if entity.valid and not entity.to_be_deconstructed(entity.force) then
 		--Go though each request slot
-		for i = 1, filterCount do
+		for i = 1, compat.version_ge(1, 1) and entity.request_slot_count or filterCount do
 			local requestItem = entity.get_request_slot(i)
 
 			--Some request slots may be empty and some items are not allowed
@@ -837,7 +839,7 @@ function UpdateInvCombinators()
 
 	for i,invControl in pairs(global.invControls) do
 		if invControl.valid then
-			invControl.parameters={parameters=invframe}
+			compat.set_parameters(invControl, invframe)
 			invControl.enabled=true
 		end
 	end

--- a/src/control.lua
+++ b/src/control.lua
@@ -115,7 +115,7 @@ function AddEntity(entity)
 end
 
 function RemoveEntity(list, entity)
-	for _, v in ipairs(list) do
+	for i, v in ipairs(list) do
 		if v.entity == entity then
 			table.remove(list, i)
 			break

--- a/src/control.lua
+++ b/src/control.lua
@@ -85,7 +85,6 @@ function AddEntity(entity)
 		table.insert(global.outputChestsData.entitiesData, {
 			entity = entity,
 			inv = entity.get_inventory(defines.inventory.chest),
-			filterCount = entity.prototype.filter_count
 		})
 	elseif entity.name == "subspace-fluid-injector" then
 		--add the chests to a lists if these chests so they can be interated over
@@ -525,12 +524,11 @@ end
 function GetOutputChestRequest(requests, entityData)
 	local entity = entityData.entity
 	local chestInventory = entityData.inv
-	local filterCount = entityData.filterCount
 	--Don't insert items into the chest if it's being deconstructed
 	--as that just leads to unnecessary bot work
 	if entity.valid and not entity.to_be_deconstructed(entity.force) then
 		--Go though each request slot
-		for i = 1, compat.version_ge(1, 1) and entity.request_slot_count or filterCount do
+		for i = 1, entity.request_slot_count do
 			local requestItem = entity.get_request_slot(i)
 
 			--Some request slots may be empty and some items are not allowed

--- a/src/control.lua
+++ b/src/control.lua
@@ -826,7 +826,9 @@ function UpdateInvCombinators()
 	local fluids = game.fluid_prototypes
 	local virtuals = game.virtual_signal_prototypes
 	if global.invdata then
-		for name,count in pairs(global.invdata) do
+		for name, count in pairs(global.invdata) do
+			-- Combinator signals are limited to a max value of 2^31-1
+			count = math.min(count, 0x7fffffff)
 			if virtuals[name] then
 				invframe[#invframe+1] = {count=count,index=#invframe+1,signal={name=name,type="virtual"}}
 			elseif fluids[name] then

--- a/src/info.json
+++ b/src/info.json
@@ -1,11 +1,26 @@
 {
     "name": "subspace_storage",
-    "version": "1.99.6",
+    "variants": [
+        {
+            "version": "1.99.6",
+            "factorio_version": "0.17",
+            "additional_files": { "compat.lua": ["compat", "factorio_0.17.lua"] }
+        },
+        {
+            "version": "1.99.7",
+            "factorio_version": "1.0",
+            "additional_files": { "compat.lua": ["compat", "factorio_1.0.lua"] }
+        },
+        {
+            "version": "1.99.8",
+            "factorio_version": "1.1",
+            "additional_files": { "compat.lua": ["compat", "factorio_1.1.lua"] }
+        }
+    ],
     "title": "Subspace Storage (Alpha)",
     "author": "Clusterio Team",
     "homepage": "https://github.com/clusterio/factorioClusterio",
     "description": "Allows storing items and fluids in a limitless shared subspace.  Warning: work in progress alpha.",
-    "factorio_version": "0.17",
     "dependencies": [
         "base",
         "clusterio_lib"

--- a/src/info.json
+++ b/src/info.json
@@ -1,6 +1,6 @@
 {
     "name": "subspace_storage",
-    "version": "1.99.4",
+    "version": "1.99.6",
     "title": "Subspace Storage (Alpha)",
     "author": "Clusterio Team",
     "homepage": "https://github.com/clusterio/factorioClusterio",

--- a/src/prototypes/entities.lua
+++ b/src/prototypes/entities.lua
@@ -7,6 +7,27 @@ local pictures = require("entity_pictures")
 local steel_chest = data.raw["container"]["steel-chest"]
 local storage_tank = data.raw["storage-tank"]["storage-tank"]
 
+-- Circuit connector helpers are defined in lualib/circuit-connector-sprites
+-- but due to the shared lua env for data stage it just exists as a global.
+local connector_definition = { variation = 25, main_offset = {1.875, 1}, shadow_offset = {4.5, 2.5625} }
+local interactor_circuit_connector_1_way = circuit_connector_definitions.create(
+	universal_connector_template,
+	{
+		connector_definition,
+	}
+)
+
+local interactor_circuit_connector_4_way = circuit_connector_definitions.create(
+	universal_connector_template,
+	{
+		connector_definition,
+		connector_definition,
+		connector_definition,
+		connector_definition,
+	}
+)
+
+
 local function subspace_interactor_entity(options)
 	local entity = {
 		name = options.name,
@@ -26,10 +47,14 @@ local function subspace_interactor_entity(options)
 		},
 		fast_replaceable_group = "subspace-interactor",
 		vehicle_impact_sound = steel_chest.vehicle_impact_sound,
-		circuit_wire_connection_point = nil,
-		circuit_connector_sprites = nil,
-		circuit_wire_max_distance = nil,
 	}
+
+	if options.circuit_connector then
+		entity.circuit_wire_connection_points = options.circuit_connector.points
+		entity.circuit_wire_connection_point = options.circuit_connector.points
+		entity.circuit_connector_sprites = options.circuit_connector.sprites
+		entity.circuit_wire_max_distance = 9
+	end
 
 	for key, value in pairs(options.entity_properties) do
 		entity[key] = value
@@ -83,6 +108,7 @@ subspace_interactor_entity {
 		opened_duration = logistic_chest_opened_duration,
 		picture = pictures["subspace-item-extractor"],
 	},
+	circuit_connector = interactor_circuit_connector_1_way,
 }
 
 subspace_interactor_entity {
@@ -96,6 +122,7 @@ subspace_interactor_entity {
 		close_sound = steel_chest.open_sound,
 		picture = pictures["subspace-item-injector"],
 	},
+	circuit_connector = interactor_circuit_connector_1_way,
 }
 
 subspace_interactor_entity {
@@ -133,6 +160,7 @@ subspace_interactor_entity {
 		close_sound = storage_tank.close_sound,
 		water_reflection = nil,
 	},
+	circuit_connector = interactor_circuit_connector_4_way,
 }
 
 subspace_interactor_entity {
@@ -210,7 +238,8 @@ subspace_interactor_entity {
 		close_sound = storage_tank.close_sound,
 		working_sound = nil,
 		default_output_signal = {type = "virtual", name = "signal-A"},
-	}
+	},
+	circuit_connector = interactor_circuit_connector_1_way,
 }
 
 subspace_interactor_entity {

--- a/src/prototypes/entities.lua
+++ b/src/prototypes/entities.lua
@@ -100,7 +100,7 @@ subspace_interactor_entity {
 		type = "logistic-container",
 		inventory_size = 60,
 		logistic_mode = "buffer",
-		logistic_slots_count = compat.version_ge(1, 1) and 18 or nil,
+		logistic_slots_count = not compat.version_ge(1, 1) and 18 or nil,
 		render_not_in_network_icon = false,
 		open_sound = steel_chest.open_sound,
 		close_sound = steel_chest.open_sound,

--- a/src/prototypes/entities.lua
+++ b/src/prototypes/entities.lua
@@ -16,7 +16,7 @@ local function subspace_interactor_entity(options)
 		max_health = 500,
 		corpse = nil,
 		dying_explosion = nil,
-		collision_box = {{-3.85, -3.85}, {3.85, 3.85}},
+		collision_box = {{-3.7, -3.7}, {3.7, 3.7}},
 		selection_box = {{-4, -4}, {4, 4}},
 		damaged_trigger_effect = steel_chest.damaged_trigger_effect,
 		resistances = {

--- a/src/prototypes/entities.lua
+++ b/src/prototypes/entities.lua
@@ -1,3 +1,4 @@
+local compat = require("compat")
 local icons = require("entity_icons")
 local pictures = require("entity_pictures")
 
@@ -74,7 +75,7 @@ subspace_interactor_entity {
 		type = "logistic-container",
 		inventory_size = 60,
 		logistic_mode = "buffer",
-		logistic_slots_count = 18,
+		logistic_slots_count = compat.version_ge(1, 1) and 18 or nil,
 		render_not_in_network_icon = false,
 		open_sound = steel_chest.open_sound,
 		close_sound = steel_chest.open_sound,


### PR DESCRIPTION
Fixes from bugs discovered in the alpha cluster and an update to the build system so that it can build for multiple Factorio versions at once with different compatibility shims for each.